### PR TITLE
feat: implement `session` deletion

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -42,12 +42,24 @@ async function setSessionCookie(sessionToken, response) {
   response.setHeader("Set-Cookie", setCookie);
 }
 
+async function clearSessionCookie(response) {
+  const setCookie = cookie.serialize("session_id", "invalid", {
+    path: "/",
+    maxAge: -1,
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+  });
+
+  response.setHeader("Set-Cookie", setCookie);
+}
+
 const controller = {
   errorHandlers: {
     onNoMatch: onNoMatchHandler,
     onError: onErrorHandler,
   },
   setSessionCookie,
+  clearSessionCookie,
 };
 
 export default controller;

--- a/models/session.js
+++ b/models/session.js
@@ -85,11 +85,36 @@ async function renew(sessionId) {
   }
 }
 
+async function expireById(sessionId) {
+  const expiredSessionObject = runUpdateQuery(sessionId);
+  return expiredSessionObject;
+
+  async function runUpdateQuery(sessionId) {
+    const results = await database.query({
+      text: `
+        UPDATE 
+          sessions
+        SET 
+          expires_at = expires_at - INTERVAL '1 year',
+          updated_at = NOW()
+        WHERE 
+          id = $1
+        RETURNING 
+          *
+      ;`,
+      values: [sessionId],
+    });
+
+    return results.rows[0];
+  }
+}
+
 const session = {
   create,
   EXPIRATION_IN_MILISECONDS,
   findOneValidByToken,
   renew,
+  expireById,
 };
 
 export default session;

--- a/pages/api/v1/sessions/index.js
+++ b/pages/api/v1/sessions/index.js
@@ -7,6 +7,7 @@ import session from "models/session.js";
 const router = createRouter();
 
 router.post(postHandler);
+router.delete(deleteHandler);
 
 export default router.handler(controller.errorHandlers);
 
@@ -23,4 +24,14 @@ async function postHandler(request, response) {
   controller.setSessionCookie(newSession.token, response);
 
   return response.status(201).json(newSession);
+}
+
+async function deleteHandler(request, response) {
+  const sessionToken = request.cookies.session_id;
+
+  const sessionObject = await session.findOneValidByToken(sessionToken);
+  const expiredSession = await session.expireById(sessionObject.id);
+  controller.clearSessionCookie(response);
+
+  return response.status(200).json(expiredSession);
 }

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -1,0 +1,143 @@
+import { version as uuidVersion } from "uuid";
+import setCookieParser from "set-cookie-parser";
+import orchestrator from "tests/orchestrator.js";
+import session from "models/session.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("DELETE /api/v1/sessions", () => {
+  describe("Default user", () => {
+    test("With nonexistant session", async () => {
+      const nonexistantToken =
+        "677e59dd5276835dcf1bbb69a8c3e0aecbf90a458c102e743511cb336e9dfd02da3888b20072c0e27a6fb66082cf00be";
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          cookie: `session_id=${nonexistantToken}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - session.EXPIRATION_IN_MILISECONDS),
+      });
+
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithExpiredSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With valid session", async () => {
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithValidSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: sessionObject.id,
+        token: sessionObject.token,
+        user_id: sessionObject.user_id,
+        expires_at: responseBody.expires_at,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(
+        responseBody.expires_at < sessionObject.expires_at.toISOString(),
+      ).toBe(true);
+      expect(
+        responseBody.updated_at > sessionObject.updated_at.toISOString(),
+      ).toBe(true);
+
+      // Set-cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
+
+      // Double check assertions
+
+      const doubleCheckResponse = await fetch(
+        "http://localhost:3000/api/v1/user",
+        {
+          headers: {
+            Cookie: `session_id=${sessionObject.token}`,
+          },
+        },
+      );
+
+      expect(doubleCheckResponse.status).toBe(401);
+
+      const doubleCheckResponseBody = await doubleCheckResponse.json();
+
+      expect(doubleCheckResponseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds support for logging out users by allowing sessions to be invalidated via a new DELETE endpoint. It introduces backend logic to expire sessions, clears the session cookie on logout, and adds comprehensive integration tests to ensure correct behavior for various scenarios.

**Session logout API and backend logic:**

* Added a `DELETE /api/v1/sessions` endpoint that allows users to log out by invalidating their session. This includes a new `deleteHandler` that finds the current session, expires it in the database, and clears the session cookie. (`pages/api/v1/sessions/index.js`, [[1]](diffhunk://#diff-b8b11a6324d139cd60a3671ff4128435c91de48c9c5640f29ae67eba3d9b2ae5R10) [[2]](diffhunk://#diff-b8b11a6324d139cd60a3671ff4128435c91de48c9c5640f29ae67eba3d9b2ae5R28-R37)
* Implemented `expireById` in the `session` model to mark a session as expired by updating its `expires_at` field. (`models/session.js`, [models/session.jsR88-R117](diffhunk://#diff-0bbdf4f340d53a73fe1ea2d8168a00e3bc8b14ef684e140570ec0af974456ffcR88-R117))
* Added `clearSessionCookie` to the controller to remove the session cookie from the user's browser. (`infra/controller.js`, [infra/controller.jsR45-R62](diffhunk://#diff-e975d7774969b5f770eb2405589934cff0a701cb679ad3ca6ca342799c58d236R45-R62))

**Testing and validation:**

* Added integration tests for the session deletion endpoint, covering cases for non-existent, expired, and valid sessions, including cookie clearing and double-checking session invalidation. (`tests/integration/api/v1/sessions/delete.test.js`, [tests/integration/api/v1/sessions/delete.test.jsR1-R143](diffhunk://#diff-eb7f1092873bea2314d89578de3411f7dd779a6804619ec4b59b0ecc3b21286aR1-R143))