### PR TITLE
feat: invalidate `session` cookie on unauthorized error

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -14,11 +14,12 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
-  if (
-    error instanceof ValidationError ||
-    error instanceof NotFoundError ||
-    error instanceof UnauthorizedError
-  ) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return response.status(error.statusCode).json(error);
+  }
+
+  if (error instanceof UnauthorizedError) {
+    clearSessionCookie(response);
     return response.status(error.statusCode).json(error);
   }
 

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -90,6 +90,19 @@ describe("GET /api/v1/user", () => {
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
       });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
     });
 
     test("With expired session", async () => {
@@ -120,6 +133,19 @@ describe("GET /api/v1/user", () => {
         message: "Usuário não possui sessão ativa.",
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
+      });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
       });
     });
 


### PR DESCRIPTION
This pull request improves how unauthorized errors are handled by ensuring the session cookie is cleared when an unauthorized error occurs, and adds integration tests to verify this behavior. The main changes are grouped into error handling improvements and test coverage enhancements.

**Error Handling Improvements:**

* Updated `onErrorHandler` in `infra/controller.js` to clear the session cookie using `clearSessionCookie(response)` when an `UnauthorizedError` is encountered, ensuring that invalid sessions are properly invalidated.

**Test Coverage Enhancements:**

* Added assertions in `tests/integration/api/v1/user/get.test.js` to verify that the `session_id` cookie is set to `"invalid"` with `maxAge: -1` and `httpOnly: true` when a request is made with an invalid or expired session. This ensures that the session cookie is correctly cleared in these scenarios. [[1]](diffhunk://#diff-8f4a0c1d7ab5ab4482895acb011594e3d0f7f5ad1206d124519cd35b1aa3df94R93-R105) [[2]](diffhunk://#diff-8f4a0c1d7ab5ab4482895acb011594e3d0f7f5ad1206d124519cd35b1aa3df94R137-R149)