### PR TITLE
fix: correct faker import path and useFakeTimers now value in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .next
 node_modules
+CLAUDE.local.md

--- a/models/authentication.js
+++ b/models/authentication.js
@@ -2,7 +2,7 @@ import user from "models/user.js";
 import password from "models/password.js";
 import { NotFoundError, UnauthorizedError } from "infra/errors.js";
 
-async function getAuthenticatedUser(providedEmail, providedPassword) {
+async function getUser(providedEmail, providedPassword) {
   try {
     const storedUser = await findUserByEmail(providedEmail);
     await validatedPassword(providedPassword, storedUser.password);
@@ -53,7 +53,7 @@ async function getAuthenticatedUser(providedEmail, providedPassword) {
 }
 
 const authentication = {
-  getAuthenticatedUser,
+  getUser,
 };
 
 export default authentication;

--- a/pages/api/v1/sessions/index.js
+++ b/pages/api/v1/sessions/index.js
@@ -16,7 +16,7 @@ export default router.handler(controller.errorHandlers);
 async function postHandler(request, response) {
   const userInputValues = request.body;
 
-  const authenticatedUser = await authentication.getAuthenticatedUser(
+  const authenticatedUser = await authentication.getUser(
     userInputValues.email,
     userInputValues.password,
   );

--- a/tests/integration/api/v1/activations/[token_id]/patch.test.js
+++ b/tests/integration/api/v1/activations/[token_id]/patch.test.js
@@ -34,7 +34,7 @@ describe("PATCH /api/v1/activations/[token_id]", () => {
 
     test("With expired token", async () => {
       jest.useFakeTimers({
-        now: new Date(Date.now() - 2 * activation.EXPIRATION_IN_MILISECONDS),
+        now: Date.now() - 2 * activation.EXPIRATION_IN_MILISECONDS,
       });
 
       const createdUser = await orchestrator.createUser();

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -36,7 +36,7 @@ describe("DELETE /api/v1/sessions", () => {
 
     test("With expired session", async () => {
       jest.useFakeTimers({
-        now: new Date(Date.now() - session.EXPIRATION_IN_MILISECONDS),
+        now: Date.now() - session.EXPIRATION_IN_MILISECONDS,
       });
 
       const createdUser = await orchestrator.createUser({

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -126,7 +126,7 @@ describe("GET /api/v1/user", () => {
 
     test("With expired session", async () => {
       jest.useFakeTimers({
-        now: new Date(Date.now() - session.EXPIRATION_IN_MILISECONDS),
+        now: Date.now() - session.EXPIRATION_IN_MILISECONDS,
       });
 
       const createdUser = await orchestrator.createUser({

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,5 +1,5 @@
 import retry from "async-retry";
-import { faker } from "@faker-js/faker/.";
+import { faker } from "@faker-js/faker";
 
 import database from "infra/database.js";
 import migrator from "models/migrator.js";


### PR DESCRIPTION
- Fix @faker-js/faker/. typo in orchestrator.js
- Pass numeric ms to jest.useFakeTimers({ now }) instead of Date object
- Rename getAuthenticatedUser to getUser in authentication model